### PR TITLE
Fix typo: consIdered -> considered in comment of LayerPermission

### DIFF
--- a/permission.go
+++ b/permission.go
@@ -34,7 +34,7 @@ func (p *StdPermission) Match(a Permission) bool {
 }
 
 // LayerPermission firstly checks the Id of permission.
-// If the Id is matched, it can be consIdered having the permission.
+// If the Id is matched, it can be considered having the permission.
 // Otherwise, it checks every layers of permission.
 // A role which has an upper layer granted, will be granted sub-layers permissions.
 type LayerPermission struct {


### PR DESCRIPTION
Fix typo of the comment of LayerPermission.

The 'i' in 'considered' is written with capital 'I', which looks like 'consldered'.

