### PR TITLE
Make `StdPermission` implement `Permission` interface

### DIFF
--- a/permission.go
+++ b/permission.go
@@ -24,12 +24,12 @@ func NewStdPermission(id string) Permission {
 }
 
 // ID returns the identity of permission
-func (p *StdPermission) ID() string {
+func (p StdPermission) ID() string {
 	return p.IDStr
 }
 
 // Match another permission
-func (p *StdPermission) Match(a Permission) bool {
+func (p StdPermission) Match(a Permission) bool {
 	return p.IDStr == a.ID()
 }
 


### PR DESCRIPTION
If the `StdPermission` methods have pointer receivers they do not implement the `Permission` interface.