### PR TITLE
fix: change common match for checking permissons to regex match

### DIFF
--- a/permission.go
+++ b/permission.go
@@ -1,5 +1,10 @@
 package gorbac
 
+import (
+	"fmt"
+	"regexp"
+)
+
 // Permission interface
 // T is the type of permission ID
 type Permission[T comparable] interface {
@@ -26,5 +31,7 @@ func (p StdPermission[T]) ID() T {
 
 // Match another permission
 func (p StdPermission[T]) Match(a Permission[T]) bool {
-	return p.SID == a.ID()
+	match, _ := regexp.Match(fmt.Sprintf("%v", p.SID), []byte(fmt.Sprintf("%v", a.ID())))
+
+	return match
 }


### PR DESCRIPTION
Hi, by merging this, we can have regular expression matching for permission verification. This improvement will guarantee smooth functionality in scenarios like the one provided as an example.
```go
package main

import (
	"fmt"
	"github.com/mikespook/gorbac"
)

func main() {
	rbac := gorbac.New()
	rA := gorbac.NewRole("role-a")
	p := gorbac.NewPermission("permission-*")
	pA := gorbac.NewPermission("permission-a")
	pB := gorbac.NewPermission("permission-b")
	pC := gorbac.NewPermission("permission-c")
	pD := gorbac.NewPermission("permission-d")
	rA.Assign(p)
	rbac.Add(rA)
	if rbac.IsGranted("role-a", pA, nil) &&
		rbac.IsGranted("role-a", pB, nil) &&
		rbac.IsGranted("role-a", pC, nil) &&
		rbac.IsGranted("role-a", pD, nil) {
		fmt.Println("The role-a has been granted permission a, b, c and d.")
	}
}
//The role-a has been granted permission a, b, c and d.
```